### PR TITLE
Rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # easy_debounce
 
-An extremely easy-to-use method call **debouncer** and **throttler** package for Dart/Flutter.
+An extremely easy-to-use method call **debouncer**, **throttler**, **rate limiter** package for Dart/Flutter.
 
 #### Debouncing
 Debouncing is needed when there is a possibility of multiple calls to a method being made within a short duration of each other, and it's desireable that only the last of those calls actually invoke the target method.
@@ -10,6 +10,10 @@ So basically each call starts a timer, and if another call happens before the ti
 
 #### Throttling
 Throttling is sort of the opposite of debouncing - only the first call to a method actually invokes the method, and any subsequent calls that are made within a specified duration are ignored. This can be useful to throttle presses on a refresh button for example.
+
+
+#### Rate limiting
+Rate limiting is similar to throttling - the first call to a method actually invokes the method, and any subsequent calls that are made within a specified duration are recorded and the once the duration has elapsed then the last call will be executed. This can be useful to rate limit progress updates as you want the first, last and periodic updates in between.
 
 
 ## Usage
@@ -83,4 +87,36 @@ You can get the number of active throttlers (throttlers which are still ignoring
 
     print('Active throttlers: ${EasyThrottle.count()}'); 
 
+
+
+### Rate Limiting
+Use the rate limiter by calling `rateLimit`:
+
+    EasyRateLimit.rateLimit(
+        'my-ratelimiter',               // <-- An ID for this particular rate limiter
+        Duration(milliseconds: 500),    // <-- The rate limiter duration
+        () => myMethod()                // <-- The target method
+        onAfter: (){ ... }              // <-- Optional callback, called after the duration has passed 
+    );
+
+The above call will invoke `myMethod()` once, and any subsequent calls to `rateLimit()` with the same `tag` within 500 ms are recorded, after 500 ms has elapsed the last call will be executed until no calls have been made within the subsequent 500 ms durations. A `tag` identifies this particular rate limiter, which means you can have multiple different rate limiters running concurrently and independent of each other.
+
+The `onAfter` callback will be invoked on duration after the rate limiter has no calls to execute.
+
+#### Cancelling a rate limiter
+
+A rate limiter which is waiting for the duration to pass can be called by calling `cancel()` with the rate limiter `tag`:
+
+    EasyRateLimit.cancel('my-ratelimiter');
+
+To cancel all active rate limiters, call `cancelAll()`:
+
+    EasyRateLimit.cancelAll();
+
+
+#### Counting active rate limiter
+
+You can get the number of active rate limiters (rate limiters which are still ignoring subsequent calls to their target methods) by calling `count()`:
+
+    print('Active rate limiters: ${EasyRateLimit.count()}'); 
 

--- a/lib/easy_ratelimit.dart
+++ b/lib/easy_ratelimit.dart
@@ -1,0 +1,90 @@
+library easy_debounce;
+
+import 'dart:async';
+
+typedef EasyRateLimitCallback = void Function();
+
+class _EasyRateLimitOperation {
+  EasyRateLimitCallback? callback;
+  EasyRateLimitCallback? onAfter;
+
+  Timer timer;
+
+  _EasyRateLimitOperation(
+    this.timer,
+  );
+}
+
+class EasyRateLimit {
+  static Map<String, _EasyRateLimitOperation> _operations = {};
+
+  /// Will execute [onExecute] immediately and record additional attempts to
+  /// call rateLimit with the same [tag] happens until the given [duration] has passed
+  /// when it will execute with the last attempt.
+  ///
+  /// [tag] is any arbitrary String, and is used to identify this particular rate limited
+  /// operation in subsequent calls to [rateLimit()] or [cancel()].
+  ///
+  /// [duration] is the amount of time until the subsequent attempts will be sent.
+  ///
+  /// [onAfter] is executed after the [duration] has passed in which there were no rate limited calls.
+  ///
+  /// Returns whether the operation was rate limited
+  static bool rateLimit(
+    String tag,
+    Duration duration,
+    EasyRateLimitCallback onExecute, {
+    EasyRateLimitCallback? onAfter,
+  }) {
+    final rateLimited = _operations.containsKey(tag);
+    if (rateLimited) {
+      _operations[tag]?.callback = onExecute;
+      _operations[tag]?.onAfter = onAfter;
+      return true;
+    }
+
+    final operation = _EasyRateLimitOperation(
+      Timer.periodic(duration, (Timer timer) {
+        final operation = _operations[tag];
+
+        if (operation != null) {
+          if (operation.callback == null) {
+            operation.timer.cancel();
+            _operations.remove(tag);
+            onAfter?.call();
+          } else {
+            operation.callback?.call();
+            operation.onAfter?.call();
+            operation.callback = null;
+            operation.onAfter = null;
+          }
+        }
+      }),
+    );
+
+    _operations[tag] = operation;
+
+    onExecute();
+
+    return false;
+  }
+
+  /// Cancels any active rate limiter with the given [tag].
+  static void cancel(String tag) {
+    _operations[tag]?.timer.cancel();
+    _operations.remove(tag);
+  }
+
+  /// Cancels all active rate limiters.
+  static void cancelAll() {
+    for (final operation in _operations.values) {
+      operation.timer.cancel();
+    }
+    _operations.clear();
+  }
+
+  /// Returns the number of active rate limiters
+  static int count() {
+    return _operations.length;
+  }
+}

--- a/test/easy_ratelimit_test.dart
+++ b/test/easy_ratelimit_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:easy_debounce/easy_rateLimit.dart';
+
+void main() {
+
+  tearDown(() async {
+    final Completer completer = new Completer();
+    late Timer tearDownTimer;
+
+    tearDownTimer = Timer.periodic(Duration(milliseconds: 100), (_) {
+      if (EasyRateLimit.count() == 0) {
+        tearDownTimer.cancel();
+        completer.complete();
+      }
+    });
+
+    return completer.future;
+  });
+
+  test('onExecute is never invoked for only 1 of the rate limited calls', () {
+    final String id = "never-invoked";
+
+    var onExecute = expectAsync1((String value) {
+      expect(value, id);
+    }, count: 2);
+
+    EasyRateLimit.rateLimit(id, Duration(milliseconds: 100), () => onExecute(id));
+    EasyRateLimit.rateLimit(id, Duration(milliseconds: 100), () => onExecute(id));
+    EasyRateLimit.rateLimit(id, Duration(milliseconds: 100), () => onExecute(id));
+    EasyRateLimit.rateLimit(id, Duration(milliseconds: 100), () => onExecute(id));
+  });
+
+  test('onExecute is called with no delay', () {
+    DateTime start = DateTime.now();
+
+    var onExecute = expectAsync0(() {
+      Duration startStopDiff = DateTime.now().difference(start);
+      int actualExpectedDiffMs = startStopDiff.inMilliseconds.abs();
+      expect(actualExpectedDiffMs < 10, true); // 10 ms is reasonable
+    }, count: 1);
+
+    Duration duration = Duration(milliseconds: 100);
+    EasyRateLimit.rateLimit("no-delay", duration, () => onExecute());
+  });
+
+  test('each call to rateLimit only executes if the rateLimit has finished', () async {
+    DateTime start = DateTime.now();
+
+    var onExecute = expectAsync1((int index) {
+      Duration startStopDiff = DateTime.now().difference(start);
+      int actualExpectedDiffMs = startStopDiff.inMilliseconds.abs();
+      expect(actualExpectedDiffMs < 10 || actualExpectedDiffMs > 500, true);
+      expect(index == 0 || index == 3 || index == 4, true);
+    }, count: 3);
+
+    EasyRateLimit.rateLimit('has-finished', Duration(milliseconds: 500), () => onExecute(0));
+    for (int i = 0; i < 5; i++) {
+      await Future.delayed(Duration(milliseconds: 110));
+      EasyRateLimit.rateLimit('has-finished', Duration(milliseconds: 100), () => onExecute(i));
+    }
+  });
+
+  test('multiple rateLimits can be run at the same time and will each invoke onExecute', () async {
+    var onExecute = expectAsync0(() {}, count: 3);
+
+    EasyRateLimit.rateLimit('multiple-1', Duration(milliseconds: 300), () => onExecute());
+    EasyRateLimit.rateLimit('multiple-2', Duration(milliseconds: 300), () => onExecute());
+    EasyRateLimit.rateLimit('multiple-3', Duration(milliseconds: 300), () => onExecute());
+  });
+
+  test('the first and last calls to rateLimit invokes onExecute', () async {
+    var onExecute = expectAsync1((int i) {
+      expect(i == 1 || i == 5, true);
+    }, count: 2);
+
+    EasyRateLimit.rateLimit('first-call', Duration(milliseconds: 300), () => onExecute(1));
+    EasyRateLimit.rateLimit('first-call', Duration(milliseconds: 300), () => onExecute(2));
+    EasyRateLimit.rateLimit('first-call', Duration(milliseconds: 300), () => onExecute(3));
+    EasyRateLimit.rateLimit('first-call', Duration(milliseconds: 300), () => onExecute(4));
+    EasyRateLimit.rateLimit('first-call', Duration(milliseconds: 300), () => onExecute(5));
+  });
+
+  test('zero-duration is a valid duration', () async {
+    var onExecute = expectAsync0(() {}, count: 1);
+    EasyRateLimit.rateLimit('zero-duration', Duration.zero, () => onExecute());
+  });
+
+  test('count() returns the number of active rateLimits', () async {
+    var onExecute = expectAsync0(() {}, count: 3);
+    expect(EasyRateLimit.count(), 0);
+    EasyRateLimit.rateLimit('count-1', Duration(milliseconds: 500), () => onExecute());
+    expect(EasyRateLimit.count(), 1);
+    EasyRateLimit.rateLimit('count-2', Duration(milliseconds: 500), () => onExecute());
+    expect(EasyRateLimit.count(), 2);
+    EasyRateLimit.rateLimit('count-3', Duration(milliseconds: 500), () => onExecute());
+
+    expect(EasyRateLimit.count(), 3);
+  });
+
+  test('cancel() cancels a rateLimit', () async {
+    var onExecute = expectAsync0(() {}, count: 3);
+
+    expect(EasyRateLimit.count(), 0);
+
+    EasyRateLimit.rateLimit('cancel-cancels-1', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-cancels-2', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-cancels-3', Duration(milliseconds: 500), () => onExecute());
+
+    expect(EasyRateLimit.count(), 3);
+
+    EasyRateLimit.cancel('cancel-cancels-1');
+    EasyRateLimit.cancel('cancel-cancels-2');
+    EasyRateLimit.cancel('cancel-cancels-3');
+
+    expect(EasyRateLimit.count(), 0);
+  });
+
+  test('cancel() decreases the number of active rateLimits', () async {
+    var onExecute = expectAsync0(() {}, count: 3);
+
+    EasyRateLimit.rateLimit('cancel-count-1', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-count-2', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-count-3', Duration(milliseconds: 500), () => onExecute());
+    expect(EasyRateLimit.count(), 3);
+    EasyRateLimit.cancel('cancel-count-1');
+    expect(EasyRateLimit.count(), 2);
+  });
+
+  test('calling cancel() on a non-existing tag doesn\'t cause an exception', () async {
+    EasyRateLimit.cancel('non-existing tag');
+  });
+
+  test('cancelAll() cancels and removes all timers', () async {
+    var onExecute = expectAsync0(() {}, count: 3);
+
+    EasyRateLimit.rateLimit('cancel-all-1', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-all-2', Duration(milliseconds: 500), () => onExecute());
+    EasyRateLimit.rateLimit('cancel-all-3', Duration(milliseconds: 500), () => onExecute());
+    expect(EasyRateLimit.count(), 3);
+    EasyRateLimit.cancelAll();
+    expect(EasyRateLimit.count(), 0);
+  });
+}


### PR DESCRIPTION
Hi Magnus
This PR contains a rate limiter which we would like you to consider for inclusion in the library.
It is similar to throttle but will execute the last call made during the timeout at the end of the duration.
The use case we built the rate limiter for is a stream of status messages where we only want to update the UI for the first message and periodically from then on, with the requirement that the last message bust be shown.
Let me know if you have any questions
Kind regards
James